### PR TITLE
Test failure in testReadFromValidCSVContentString.java on Windows

### DIFF
--- a/src/main/java/io/frictionlessdata/tableschema/Schema.java
+++ b/src/main/java/io/frictionlessdata/tableschema/Schema.java
@@ -253,7 +253,7 @@ public class Schema {
     
     /**
      * Check if schema is valid or not.
-     * @return 
+     * @return
      */
     public boolean isValid(){
         try{

--- a/src/test/java/io/frictionlessdata/tableschema/SchemaTest.java
+++ b/src/test/java/io/frictionlessdata/tableschema/SchemaTest.java
@@ -34,7 +34,7 @@ public class SchemaTest {
     
     @Rule
     public final ExpectedException exception = ExpectedException.none();
-     
+
     @Test
     public void testCreateSchemaFromValidSchemaJson() throws PrimaryKeyException, ForeignKeyException{ 
         JSONObject schemaJsonObj = new JSONObject();

--- a/src/test/java/io/frictionlessdata/tableschema/TableTest.java
+++ b/src/test/java/io/frictionlessdata/tableschema/TableTest.java
@@ -2,6 +2,7 @@ package io.frictionlessdata.tableschema;
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -39,8 +40,9 @@ public class TableTest {
     @Test
     public void testReadFromValidCSVContentString() throws Exception{
         // get path of test CSV file
-        String sourceFileAbsPath = TableTest.class.getResource("/fixtures/simple_data.csv").getPath();
-        String csvContent = new String(Files.readAllBytes(Paths.get(sourceFileAbsPath)));
+        URL sourceFileUrl = TableTest.class.getResource("/fixtures/simple_data.csv");
+        Path path = Paths.get(sourceFileUrl.toURI());
+        String csvContent = new String(Files.readAllBytes(path));
         
         Table table = new Table(csvContent);
         


### PR DESCRIPTION
# Overview

Compiling the tableschema jar under Windows gives me the following test exception:

    testReadFromValidCSVContentString(io.frictionlessdata.tableschema.TableTest)  Time elapsed: 0.027 sec  <<< ERROR!
    java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:/Users/isnow/Projects/workspace/tableschema-java/target/test-classes/fixtures/simple_data.csv
        at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
        at sun.nio.fs.WindowsPath.parse(WindowsPath.java:94)
        at sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:255)
        at java.nio.file.Paths.get(Paths.java:84)
        at io.frictionlessdata.tableschema.TableTest.testReadFromValidCSVContentString(TableTest.java:43)

This is due to the incorrect construction of the path in question; a similar question and explanation can be found here: https://bugs.openjdk.java.net/browse/JDK-8197918?focusedCommentId=14156698&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14156698

The underlying problem doesn't manifest on Unix-like systems, but due to Windows peculiar file paths, it triggers an exception.

After applying the proposed solution, the test passes in my environment.

---

Please preserve this line to notify @georgeslabreche (maintainer of this repository)
