### PR TITLE
Fixed Integer field constraints to match BigInteger implementation

### DIFF
--- a/src/main/java/io/frictionlessdata/tableschema/field/Field.java
+++ b/src/main/java/io/frictionlessdata/tableschema/field/Field.java
@@ -10,7 +10,6 @@ import io.frictionlessdata.tableschema.util.JsonUtil;
 import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.net.URI;
 import java.time.*;
 import java.util.*;

--- a/src/main/java/io/frictionlessdata/tableschema/field/Field.java
+++ b/src/main/java/io/frictionlessdata/tableschema/field/Field.java
@@ -9,6 +9,8 @@ import io.frictionlessdata.tableschema.exception.InvalidCastException;
 import io.frictionlessdata.tableschema.util.JsonUtil;
 import org.apache.commons.lang3.StringUtils;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.URI;
 import java.time.*;
 import java.util.*;
@@ -334,12 +336,12 @@ public abstract class Field<T> {
          **/
         if(this.constraints.containsKey(CONSTRAINT_KEY_MINIMUM)){
             
-            if(value instanceof Integer){
-                int minInt = (int)this.constraints.get(CONSTRAINT_KEY_MINIMUM);
-                if((int)value < minInt){
-                    violatedConstraints.put(CONSTRAINT_KEY_MINIMUM, minInt);
+            if(value instanceof Number){
+                BigDecimal minNumber = new BigDecimal(this.constraints.get(CONSTRAINT_KEY_MINIMUM).toString());
+                if( new BigDecimal(value.toString()).compareTo(minNumber) < 0 ) {
+                    violatedConstraints.put(CONSTRAINT_KEY_MINIMUM, minNumber);
                 }
-                
+
             }else if(value instanceof LocalTime){
                 LocalTime minTime = (LocalTime)this.constraints.get(CONSTRAINT_KEY_MINIMUM);
                 if(((LocalTime)value).isBefore(minTime)){
@@ -358,6 +360,12 @@ public abstract class Field<T> {
                     violatedConstraints.put(CONSTRAINT_KEY_MINIMUM, minDate);
                 }
 
+            }else if(value instanceof Year){
+                int minYear = (int)this.constraints.get(CONSTRAINT_KEY_MINIMUM);
+                if(((Year)value).isBefore(Year.of(minYear))) {
+                    violatedConstraints.put(CONSTRAINT_KEY_MINIMUM, minYear);
+                    }
+
             }else if(value instanceof YearMonth){
                 YearMonth minDate = (YearMonth)this.constraints.get(CONSTRAINT_KEY_MINIMUM);
                 if(((YearMonth)value).isBefore(minDate)){
@@ -375,12 +383,11 @@ public abstract class Field<T> {
         // As for minimum, but specifies a maximum value for a field.
         if(this.constraints.containsKey(CONSTRAINT_KEY_MAXIMUM)){
             
-            if(value instanceof Integer){
-                int maxInt = (int)this.constraints.get(CONSTRAINT_KEY_MAXIMUM);
-                if((int)value > maxInt){
-                    violatedConstraints.put(CONSTRAINT_KEY_MAXIMUM, maxInt);
+            if(value instanceof Number) {
+                BigDecimal maxNumber = new BigDecimal(this.constraints.get(CONSTRAINT_KEY_MAXIMUM).toString());
+                if (new BigDecimal(value.toString()).compareTo(maxNumber) > 0) {
+                    violatedConstraints.put(CONSTRAINT_KEY_MAXIMUM, maxNumber);
                 }
-                
             }else if(value instanceof LocalTime){
                 LocalTime maxTime = (LocalTime)this.constraints.get(CONSTRAINT_KEY_MAXIMUM);
 
@@ -400,6 +407,12 @@ public abstract class Field<T> {
 
                 if(((LocalDate)value).isAfter(maxDate)){
                     violatedConstraints.put(CONSTRAINT_KEY_MAXIMUM, maxDate);
+                }
+
+            }else if(value instanceof Year){
+            int maxYear = (int)this.constraints.get(CONSTRAINT_KEY_MAXIMUM);
+                if(((Year)value).isAfter(Year.of(maxYear))){
+                    violatedConstraints.put(CONSTRAINT_KEY_MAXIMUM, maxYear);
                 }
 
             }else if(value instanceof YearMonth){

--- a/src/test/java/io/frictionlessdata/tableschema/DocumentationCases.java
+++ b/src/test/java/io/frictionlessdata/tableschema/DocumentationCases.java
@@ -119,7 +119,7 @@ class DocumentationCases {
          */
 
         ObjectMapper objectMapper = new ObjectMapper();
-        String json = schema.getJson().replaceAll("[\\n\\t ]", "");
+        String json = schema.getJson().replaceAll("[\\n\\t\\r ]", "");
         Object jsonObject = objectMapper.readValue(json, Object.class);
         String expectedString = objectMapper.writeValueAsString(jsonObject);
         assertEquals(json, expectedString);
@@ -156,7 +156,7 @@ class DocumentationCases {
         */
 
         ObjectMapper objectMapper = new ObjectMapper();
-        String json = schema.getJson().replaceAll("[\\n\\t ]", "");
+        String json = schema.getJson().replaceAll("[\\n\\t\\r ]", "");
         Object jsonObject = objectMapper.readValue(json, Object.class);
         String expectedString = objectMapper.writeValueAsString(jsonObject);
         assertEquals(json, expectedString);
@@ -180,7 +180,7 @@ class DocumentationCases {
          */
 
         ObjectMapper objectMapper = new ObjectMapper();
-        String json = schema.getJson().replaceAll("[\\n\\t ]", "");
+        String json = schema.getJson().replaceAll("[\\n\\t\\r ]", "");
         Object jsonObject = objectMapper.readValue(json, Object.class);
         String expectedString = objectMapper.writeValueAsString(jsonObject);
         assertEquals(json, expectedString);

--- a/src/test/java/io/frictionlessdata/tableschema/field/FieldConstraintsTest.java
+++ b/src/test/java/io/frictionlessdata/tableschema/field/FieldConstraintsTest.java
@@ -3,6 +3,7 @@ package io.frictionlessdata.tableschema.field;
 import io.frictionlessdata.tableschema.exception.ConstraintsException;
 import io.frictionlessdata.tableschema.util.JsonUtil;
 
+import java.math.BigInteger;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -208,8 +209,45 @@ public class FieldConstraintsTest {
         }
     }
 
+    @Test
+    public void testMinimumAndMaximumBigInteger(){
+        Map<String, Object> constraints = new HashMap();
+        constraints.put(Field.CONSTRAINT_KEY_MINIMUM, 2);
+        constraints.put(Field.CONSTRAINT_KEY_MAXIMUM, 5);
+
+        IntegerField field = new IntegerField("test", Field.FIELD_FORMAT_DEFAULT, null, null, null, constraints, null);
+
+        for(int i=0; i < 7; i++){
+            Map<String, Object> violatedConstraints = field.checkConstraintViolations(BigInteger.valueOf(i));
+            if(i >= 2 && i <=5){
+                Assert.assertTrue(violatedConstraints.isEmpty());
+            }else if(i < 2){
+                Assert.assertTrue(violatedConstraints.containsKey(Field.CONSTRAINT_KEY_MINIMUM));
+            }else if(i > 5){
+                Assert.assertTrue(violatedConstraints.containsKey(Field.CONSTRAINT_KEY_MAXIMUM));
+            }
+        }
+    }
+
+    @Test
     public void testMinimumAndMaximumNumber(){
-        //TODO: Implement
+        Map<String, Object> constraints = new HashMap();
+        constraints.put(Field.CONSTRAINT_KEY_MINIMUM, 2.0);
+        constraints.put(Field.CONSTRAINT_KEY_MAXIMUM, 5.0);
+
+        NumberField field = new NumberField("test", Field.FIELD_FORMAT_DEFAULT, null, null, null, constraints, null);
+
+        for(int i=0; i < 7; i++){
+            Map<String, Object> violatedConstraints = field.checkConstraintViolations(i);
+
+            if(i >= 2 && i <=5){
+                Assert.assertTrue(violatedConstraints.isEmpty());
+            }else if(i < 2){
+                Assert.assertTrue(violatedConstraints.containsKey(Field.CONSTRAINT_KEY_MINIMUM));
+            }else if(i > 5){
+                Assert.assertTrue(violatedConstraints.containsKey(Field.CONSTRAINT_KEY_MAXIMUM));
+            }
+        }
     }
 
     @Test
@@ -369,7 +407,7 @@ public class FieldConstraintsTest {
         YearField field = new YearField("test",  "default", "title", "desc", null, constraints, null);
 
         for(int i=1990; i < 2020; i++){
-            Map<String, Object> violatedConstraints = field.checkConstraintViolations(i);
+            Map<String, Object> violatedConstraints = field.checkConstraintViolations(Year.of(i));
 
             if(i >= 1999 && i <=2018){
                 Assert.assertTrue(violatedConstraints.isEmpty());


### PR DESCRIPTION
# Constraints for integer and number fields were not being checked properly

As the implementation of number field and integer field both use BigNumber and BigInteger which inherit from Number not Integer checking "instanceof Integer" would never be true causing constraint validation to always pass for these fields.

Updated unit tests to use the correct data type.

Also added year constraint check as it was not present.

---

Please preserve this line to notify @iSnow (lead of this repository)
