### PR TITLE
always use ENGLISH locale for NumberField

### DIFF
--- a/src/main/java/io/frictionlessdata/tableschema/field/NumberField.java
+++ b/src/main/java/io/frictionlessdata/tableschema/field/NumberField.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.text.NumberFormat;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -28,7 +29,7 @@ public class NumberField extends Field<Number> {
     private static final String REGEX_INTEGER = "[+-]?\\d+";
     private static final String REGEX_BARE_NUMBER = "((^\\D*)|(\\D*$))";
 
-    private static final NumberFormat numberFormat = NumberFormat.getInstance();
+    private static final NumberFormat numberFormat = NumberFormat.getInstance(Locale.ENGLISH);
     static {
         numberFormat.setMaximumFractionDigits(Integer.MAX_VALUE);
         numberFormat.setGroupingUsed(false);


### PR DESCRIPTION
To become independent of the Locale of the runtime system the locale (used to format numbers) should always be ENGLISH.

fixes #67

---

Please preserve this line to notify @iSnow (lead of this repository)
