### PR TITLE
Map empty value to string, fix correct most inferred order

### DIFF
--- a/src/main/java/io/frictionlessdata/tableschema/field/NumberField.java
+++ b/src/main/java/io/frictionlessdata/tableschema/field/NumberField.java
@@ -52,10 +52,6 @@ public class NumberField extends Field<Number> {
     public Number parseValue(String value, String format, Map<String, Object> options) throws InvalidCastException, ConstraintsException {
         String locValue = value.trim();
         try{
-            if (value.equalsIgnoreCase("null"))
-                return null;
-            if (value.length() == 0)
-                return null;
             if(options != null){
                 if(options.containsKey(NUMBER_OPTION_DECIMAL_CHAR)){
                     locValue = locValue.replace((String)options.get(NUMBER_OPTION_DECIMAL_CHAR), NUMBER_DEFAULT_DECIMAL_CHAR);

--- a/src/main/java/io/frictionlessdata/tableschema/schema/TypeInferrer.java
+++ b/src/main/java/io/frictionlessdata/tableschema/schema/TypeInferrer.java
@@ -129,7 +129,7 @@ public class TypeInferrer {
             TreeMap<String, Integer> typeInferralCountMapSortedByCount = sortMapByValue(typeInferralCountMap); 
            
             if(!typeInferralCountMapSortedByCount.isEmpty()){
-                String inferredType = typeInferralCountMapSortedByCount.firstEntry().getKey();
+                String inferredType = typeInferralCountMapSortedByCount.lastEntry().getKey();
                 fieldArray.get(j).put(Field.JSON_KEY_TYPE, inferredType);
                 fieldArray.get(j).put(Field.JSON_KEY_FORMAT, formatMap.get(headers[j]));
             }


### PR DESCRIPTION
# Overview

This pull request, is also a fix for issue #72 
According the documentation, the NumberField is a not empty digit sequence. The most inferred map is sorted in ascending order so the lastEntry must be considered for the most inferred.

---

Please preserve this line to notify @iSnow (lead of this repository)
