### PR TITLE
added an optional parameter to specify the character encoding of a source

### DIFF
--- a/src/main/java/io/frictionlessdata/tableschema/Table.java
+++ b/src/main/java/io/frictionlessdata/tableschema/Table.java
@@ -18,6 +18,8 @@ import org.apache.commons.csv.CSVPrinter;
 
 import java.io.*;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
@@ -123,12 +125,29 @@ public class Table{
      * @param format The expected CSVFormat if dataSource is a CSV-containing InputStream; ignored for JSON data.
      *               Can be `null`
      */
-    public static Table fromSource(File dataSource, File basePath, Schema schema, CSVFormat format) {
-        Table table = fromSource(dataSource, basePath);
+    public static Table fromSource(File dataSource, File basePath, Schema schema, CSVFormat format, Charset charset) {
+        Table table = fromSource(dataSource, basePath, charset);
         table.schema = schema;
         if (null != format) {
             table.setCsvFormat(format);
         }
+        return table;
+    }
+
+    public static Table fromSource(File dataSource, File basePath, Schema schema, CSVFormat format) {
+        return fromSource(dataSource, basePath, schema, format, null);
+    }
+
+        /**
+         * Create Table from a {@link java.io.File} containing the CSV/JSON
+         * data and without either a Schema or a CSVFormat.
+         * @param dataSource relative File for reading the data from. Must be inside `basePath`
+         * @param basePath Parent directory
+         * @param charset Character encoding of the file
+         */
+    public static Table fromSource(File dataSource, File basePath, Charset charset) {
+        Table table = new Table();
+        table.dataSource = TableDataSource.fromSource(dataSource, basePath, charset);
         return table;
     }
 
@@ -139,9 +158,7 @@ public class Table{
      * @param basePath Parent directory
      */
     public static Table fromSource(File dataSource, File basePath) {
-        Table table = new Table();
-        table.dataSource = TableDataSource.fromSource(dataSource, basePath);
-        return table;
+        return fromSource(dataSource, basePath, null);
     }
 
     /**

--- a/src/main/java/io/frictionlessdata/tableschema/tabledatasource/AbstractTableDataSource.java
+++ b/src/main/java/io/frictionlessdata/tableschema/tabledatasource/AbstractTableDataSource.java
@@ -3,6 +3,7 @@ package io.frictionlessdata.tableschema.tabledatasource;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -32,7 +33,7 @@ public abstract class AbstractTableDataSource<T> implements TableDataSource {
     }
 
     String getFileContents(String path) throws IOException {
-        return TableDataSource.getFileContents(path, workDir);
+        return TableDataSource.getFileContents(path, workDir, Charset.defaultCharset());
     }
 
 }

--- a/src/test/java/io/frictionlessdata/tableschema/table_tests/TableEncodingTests.java
+++ b/src/test/java/io/frictionlessdata/tableschema/table_tests/TableEncodingTests.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 
+import static io.frictionlessdata.tableschema.TestHelper.getTestDataDirectory;
 import static io.frictionlessdata.tableschema.TestHelper.getTestsuiteDataDirectory;
 
 public class TableEncodingTests {
@@ -17,12 +19,11 @@ public class TableEncodingTests {
     // currently disabled
     @Test
     @DisplayName("Create a Table from a ISO-8859-1 encoded file")
-    @Disabled
     void createTableFromIso8859() throws Exception{
-        File testDataDir = getTestsuiteDataDirectory();
+        File testDataDir = getTestDataDirectory();
 
         Table table
-                = Table.fromSource(new File("csv/encodings/iso8859.csv"), testDataDir, null, null);
+                = Table.fromSource(new File("csv/encodings/iso8859.csv"), testDataDir, null, null, StandardCharsets.ISO_8859_1);
 
         Iterator<Object[]> iter = table.iterator();
         Object[] row = iter.next();

--- a/src/test/java/io/frictionlessdata/tableschema/tabledatasource/JsonArrayTableDataSourceTest.java
+++ b/src/test/java/io/frictionlessdata/tableschema/tabledatasource/JsonArrayTableDataSourceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.stream.Collectors;
 
@@ -74,7 +75,7 @@ class JsonArrayTableDataSourceTest {
     @DisplayName("Validate creating a JsonArrayTableDataSource from JSON file")
     void testSafePathCreationJson() throws Exception {
         TableDataSource ds = TableDataSource.fromSource(new File("simple_geojson.json"),
-                TestHelper.getTestDataDirectory());
+                TestHelper.getTestDataDirectory(), Charset.defaultCharset());
         Assertions.assertNotNull(ds);
     }
 /*

--- a/src/test/java/io/frictionlessdata/tableschema/tabledatasource/TableDataSourceFormatsTest.java
+++ b/src/test/java/io/frictionlessdata/tableschema/tabledatasource/TableDataSourceFormatsTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -85,7 +86,7 @@ public class TableDataSourceFormatsTest {
     @Test
     @DisplayName("Create a TableDataSource from a safe path and ensure no exception is thrown")
     public void testSafePathCreationCsv() throws Exception {
-        TableDataSource ds = TableDataSource.fromSource(new File ("data/population.csv"), TestHelper.getTestDataDirectory());
+        TableDataSource ds = TableDataSource.fromSource(new File ("data/population.csv"), TestHelper.getTestDataDirectory(), Charset.defaultCharset());
         Assertions.assertNotNull(ds);
     }
 
@@ -162,7 +163,7 @@ public class TableDataSourceFormatsTest {
         TableDataSource ds;
         File basePath = new File(TestHelper.getTestDataDirectory(),"data/population.zip");
         File inFile = new File("population.csv");
-        ds = TableDataSource.fromSource(inFile,basePath);
+        ds = TableDataSource.fromSource(inFile,basePath, null);
         List<String[]> data = ds.getDataAsStringArray();
         Assertions.assertNotNull(data);
         byte[] bytes = Files.readAllBytes(new File(TestHelper.getTestDataDirectory(), "data/population.csv").toPath());

--- a/src/test/resources/fixtures/csv/encodings/iso8859.csv
+++ b/src/test/resources/fixtures/csv/encodings/iso8859.csv
@@ -1,0 +1,2 @@
+name
+Réunion


### PR DESCRIPTION
# Overview

I have added an optional parameter to specify the character encoding of a source. The test [TableEncodingTests::createTableFromIso8859()](https://github.com/frictionlessdata/tableschema-java/blob/main/src/test/java/io/frictionlessdata/tableschema/table_tests/TableEncodingTests.java) passes. 

However, I'm not at all sure that my approach makes sense in context of the rest of the code/framework. Somehow we would have to transfer the `encoding` property from the *Tabular Data Resource* to the `Table.fromSource` method invocation.

Closes #77 

---

Please preserve this line to notify @iSnow (lead of this repository)
